### PR TITLE
translated to snakemake

### DIFF
--- a/bulldozers/Snakefile
+++ b/bulldozers/Snakefile
@@ -14,10 +14,12 @@
 MODELS = ['rf', 'lm']
 INPUT_FILES = ['input/Train.csv', 'input/Machine_Appendix.csv']
 
+_model_predictions = expand('working/models/{model}/test_predictions.csv', model=MODELS)
+
 rule all: 
     input: 
         'working/models/model_performance.png', 
-        csv=expand('working/models/{model}/test_predictions.csv', model=MODELS),
+        csv=_model_predictions,
         actual_vs_predicted=expand('working/models/{model}/predicted_vs_actual.png', model=MODELS)
     shell: 
         'Rscript launch_app.R residuals "{input.csv}"'
@@ -49,7 +51,7 @@ rule test_predictions:
 
 rule model_performance:
     input: 
-        csv=expand('working/models/{model}/test_predictions.csv', model=MODELS),
+        csv=_model_predictions,
         script='scripts/model_performance.R'
     output: 'working/models/model_performance.png'
     shell: 'Rscript {input.script} {input.csv} {output}'

--- a/bulldozers/Snakefile
+++ b/bulldozers/Snakefile
@@ -1,0 +1,70 @@
+# 
+# Snakefile
+# 
+# run "pip3 install snakemake" with python3 installed
+# 
+# then execute: 
+# snakemake
+# 
+# All of these rules use `shell:` since they are relatively simple, 
+# but it is possible to use `run:` instead and execute arbitrary 
+# python code within the rule. It is also possible to execute 
+# arbitrary python outside of declared rules, i.e. the MODELS variable.
+
+MODELS = ['rf', 'lm']
+
+rule all: 
+    input: 
+        'working/models/model_performance.png', 
+        csv=expand('working/models/{model}/test_predictions.csv', model=MODELS),
+        actual_vs_predicted=expand('working/models/{model}/predicted_vs_actual.png', model=MODELS)
+    shell: 
+        'Rscript launch_app.R residuals "{input.csv}"'
+
+rule clean_input:
+    input: 
+        csv=['input/Train.csv', 'input/Machine_Appendix.csv'],
+        script='scripts/clean.R'
+    output: 'working/cleaned_input.csv'
+    shell: 'Rscript {input.script} {output} {input.csv}'
+
+rule predicted_vs_actual:
+    input: 
+        script='scripts/plot_predicted_vs_actual.R',
+        test_predictions='working/models/{model}/test_predictions.csv'
+    output: 'working/models/{model}/predicted_vs_actual.png'
+    shell:
+        'Rscript {input} {output}'
+
+rule test_predictions:
+    input:
+        script='scripts/model.R',
+        train='working/split/train.csv',
+        test='working/split/test.csv'
+    output: 'working/models/{model}/test_predictions.csv'
+    shell: 
+        'Rscript {input.script} {input.train} {input.test} {wildcards.model} {output}'
+
+
+rule model_performance:
+    input: 
+        csv=expand('working/models/{model}/test_predictions.csv', model=MODELS),
+        script='scripts/model_performance.R'
+    output: 'working/models/model_performance.png'
+    shell: 'Rscript {input.script} {input.csv} {output}'
+
+
+# Snakemake deals with multiple file targets, so we don't need to use a hack =)
+rule split:
+    input:
+        script='scripts/train_test_split.R',
+        csv='working/cleaned_input.csv'
+    output: 
+        train='working/split/train.csv', 
+        test='working/split/test.csv'
+    shell:
+        'Rscript {input.script} {output.train} {input.csv}' 
+    # here, we we could also give the output directory directly to the Rscript by doing something like
+    # run:
+    #     outdir = dirname(output[0])
+    #     shell('Rscript {input.script} {outdir} {input.csv')

--- a/bulldozers/Snakefile
+++ b/bulldozers/Snakefile
@@ -11,25 +11,25 @@
 # python code within the rule. It is also possible to execute 
 # arbitrary python outside of declared rules, i.e. the MODELS variable.
 
+from os.path import dirname
+
 MODELS = ['rf', 'lm']
 INPUT_FILES = ['input/Train.csv', 'input/Machine_Appendix.csv']
 
-_model_predictions = expand('working/models/{model}/test_predictions.csv', model=MODELS)
+_model_performance_csv = expand('working/models/{model}/test_predictions.csv', model=MODELS)
 
 rule all: 
     input: 
         'working/models/model_performance.png', 
-        csv=_model_predictions,
         actual_vs_predicted=expand('working/models/{model}/predicted_vs_actual.png', model=MODELS)
-    shell: 
-        'Rscript launch_app.R residuals "{input.csv}"'
 
-rule clean_input:
+rule residuals_app: # doesn't work? 
     input: 
-        csv=INPUT_FILES,
-        script='scripts/clean.R'
-    output: 'working/cleaned_input.csv'
-    shell: 'Rscript {input.script} {output} {input.csv}'
+        csv=_model_performance_csv,
+        script='launch_app.R'
+    output: temp('.phony') # no phony rules yet, but this works
+    shell: 'Rscript {input.script} {input.csv}'
+
 
 rule predicted_vs_actual:
     input: 
@@ -37,7 +37,15 @@ rule predicted_vs_actual:
         test_predictions='working/models/{model}/test_predictions.csv'
     output: 'working/models/{model}/predicted_vs_actual.png'
     shell:
-        'Rscript {input} {output}'
+        'Rscript {input.script} {input.test_predictions} {output}'
+
+rule model_performance:
+    input: 
+        csv=_model_performance_csv,
+        script='scripts/model_performance.R'
+    output: 'working/models/model_performance.png'
+    shell: 'Rscript {input.script} "{input.csv}" {output}'
+
 
 rule test_predictions:
     input:
@@ -49,25 +57,22 @@ rule test_predictions:
         'Rscript {input.script} {input.train} {input.test} {wildcards.model} {output}'
 
 
-rule model_performance:
-    input: 
-        csv=_model_predictions,
-        script='scripts/model_performance.R'
-    output: 'working/models/model_performance.png'
-    shell: 'Rscript {input.script} {input.csv} {output}'
-
-
 # Snakemake deals with multiple file targets, so we don't need to use a hack =)
 rule split:
     input:
-        script='scripts/train_test_split.R',
-        csv='working/cleaned_input.csv'
+        csv='working/cleaned_input.csv',
+        script='scripts/train_test_split.R'
     output: 
         train='working/split/train.csv', 
         test='working/split/test.csv'
-    shell:
-        'Rscript {input.script} {output.train} {input.csv}' 
-    # here, we we could also give the output directory directly to the Rscript by doing something like
-    # run:
-    #     outdir = dirname(output[0])
-    #     shell('Rscript {input.script} {outdir} {input.csv')
+    run: 
+        outdir = dirname(output.train)
+        shell('Rscript {input.script} {outdir} {input.csv}')
+
+rule clean_input:
+    input: 
+        csv=INPUT_FILES,
+        script='scripts/clean.R'
+    output: 'working/cleaned_input.csv'
+    shell: 'Rscript {input.script} {output} {input.csv}'
+

--- a/bulldozers/Snakefile
+++ b/bulldozers/Snakefile
@@ -23,12 +23,12 @@ rule all:
         'working/models/model_performance.png', 
         actual_vs_predicted=expand('working/models/{model}/predicted_vs_actual.png', model=MODELS)
 
-rule residuals_app: # doesn't work? 
+rule residuals_app: 
     input: 
         csv=_model_performance_csv,
         script='launch_app.R'
     output: temp('.phony') # no phony rules yet, but this works
-    shell: 'Rscript {input.script} {input.csv}'
+    shell: 'Rscript {input.script} residuals {input.csv}'
 
 
 rule predicted_vs_actual:

--- a/bulldozers/Snakefile
+++ b/bulldozers/Snakefile
@@ -12,6 +12,7 @@
 # arbitrary python outside of declared rules, i.e. the MODELS variable.
 
 MODELS = ['rf', 'lm']
+INPUT_FILES = ['input/Train.csv', 'input/Machine_Appendix.csv']
 
 rule all: 
     input: 
@@ -23,7 +24,7 @@ rule all:
 
 rule clean_input:
     input: 
-        csv=['input/Train.csv', 'input/Machine_Appendix.csv'],
+        csv=INPUT_FILES,
         script='scripts/clean.R'
     output: 'working/cleaned_input.csv'
     shell: 'Rscript {input.script} {output} {input.csv}'


### PR DESCRIPTION
I wasn't able to test this with input (I think you have `input` in your .gitignore =)) but I was able to test it using the --dryrun functionality of snakemake. 

All of these rules used the `shell:` command, but you can also execute arbitrary python code within rules using `run:`. For more examples, see [the snakemake homepage](https://bitbucket.org/johanneskoester/snakemake/wiki/Home). Thanks again for the great talk! 

```
(venv343) ➜  bulldozers git:(master) ✗ snakemake --dryrun --printshellcmds
rule clean_input:
    input: input/Train.csv, input/Machine_Appendix.csv, scripts/clean.R
    output: working/cleaned_input.csv
Rscript scripts/clean.R working/cleaned_input.csv input/Train.csv input/Machine_Appendix.csv
rule split:
    input: working/cleaned_input.csv, scripts/train_test_split.R
    output: working/split/test.csv, working/split/train.csv
Rscript scripts/train_test_split.R working/split/train.csv working/cleaned_input.csv
rule test_predictions:
    input: scripts/model.R, working/split/test.csv, working/split/train.csv
    output: working/models/lm/test_predictions.csv
Rscript scripts/model.R working/split/train.csv working/split/test.csv lm working/models/lm/test_predictions.csv
rule test_predictions:
    input: scripts/model.R, working/split/test.csv, working/split/train.csv
    output: working/models/rf/test_predictions.csv
Rscript scripts/model.R working/split/train.csv working/split/test.csv rf working/models/rf/test_predictions.csv
rule predicted_vs_actual:
    input: working/models/lm/test_predictions.csv, scripts/plot_predicted_vs_actual.R
    output: working/models/lm/predicted_vs_actual.png
Rscript working/models/lm/test_predictions.csv scripts/plot_predicted_vs_actual.R working/models/lm/predicted_vs_actual.png
rule model_performance:
    input: working/models/rf/test_predictions.csv, working/models/lm/test_predictions.csv, scripts/model_performance.R
    output: working/models/model_performance.png
Rscript scripts/model_performance.R working/models/rf/test_predictions.csv working/models/lm/test_predictions.csv working/models/model_performance.png
rule predicted_vs_actual:
    input: working/models/rf/test_predictions.csv, scripts/plot_predicted_vs_actual.R
    output: working/models/rf/predicted_vs_actual.png
Rscript working/models/rf/test_predictions.csv scripts/plot_predicted_vs_actual.R working/models/rf/predicted_vs_actual.png
rule all:
    input: working/models/model_performance.png, working/models/rf/test_predictions.csv, working/models/lm/test_predictions.csv, working/models/rf/predicted_vs_actual.png, working/models/lm/predicted_vs_actual.png
Rscript launch_app.R residuals "working/models/rf/test_predictions.csv working/models/lm/test_predictions.csv"
Job counts:
    count   jobs
    2   test_predictions
    2   predicted_vs_actual
    1   all
    1   clean_input
    1   split
    1   model_performance
    8
```
